### PR TITLE
Fix no ini changes

### DIFF
--- a/post_install.sh
+++ b/post_install.sh
@@ -1,12 +1,12 @@
 #!/bin/sh
 # Enable and start the service to generate the config file
 sysrc sabnzbd_enable="YES"
-service sabnzbd start 
+service sabnzbd start
 # Sleep is needed because iocage doesn’t read line by line but rather reads it in all at once
 sleep 5
+timeout 10 sh -c 'while [ ! -f /usr/local/sabnzbd/sabnzbd.ini ]; do sleep 1; done'
+service sabnzbd stop
 # Edit config to allow outside access
 sed -i '' 's/127.0.0.1/0.0.0.0/g' /usr/local/sabnzbd/sabnzbd.ini
-# Restart the service for config change to take 
-service sabnzbd restart
-
-
+# Restart the service for config change to take
+service sabnzbd start


### PR DESCRIPTION
Related to issue: https://github.com/ix-plugin-hub/iocage-plugin-index/issues/224 where the plugin UI doesn't seem to be reachable due to old loclahost in ini config file.

Fix = Wait for the ini file to be created after starting the service the first time, stop it and, then changed the host to `0.0.0.0` and finally start it up again.